### PR TITLE
fix the user right issue on Vagrant up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 # vim:set ft=dockerfile
-FROM phusion/baseimage:noble-1.0.0
+
+# on July 2024, switching to noble (24.04 LTS) causes issues
+# because it will mount the volume on "vagrant up" with default user "ubuntu"
+# instead of the expected one "vagrant"
+#
+# this cause rights and privileges issues for all commands coming after
+FROM phusion/baseimage:jammy-1.0.0
 
 ENV SUDOFILE /etc/sudoers
 

--- a/change_user_uid.sh
+++ b/change_user_uid.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
-usermod -u $HOST_USER_UID vagrant
-if test -z "$@"; then
+
+# if needed, we change the uid of the vagrant user
+# so that to be sure it matches the one of the host
+# this way, changing a file from within the container
+# does not alter ownership
+if ! [ $(id -u vagrant) = $HOST_USER_UID ]; then
+    usermod -u $HOST_USER_UID vagrant
+fi
+if ! [ $(id -g vagrant) = $HOST_USER_GID ]; then
+    groupmod -g $HOST_USER_GID vagrant
+fi
+if  test -z "$@" ; then
     /sbin/my_init
 else
     exec "$@"


### PR DESCRIPTION
using Ubutnu 24.04 LTS as a base image makes the mounted directory default owner "ubuntu" instead of "vagrant";

this causes issues afterwards for all the executed commands as they are all run with vagrant user